### PR TITLE
Fixes #25: re-order samples according to group factors in QC plots

### DIFF
--- a/amica/R/server/qcPlots.R
+++ b/amica/R/server/qcPlots.R
@@ -422,6 +422,13 @@ plotNumberIdentifiedProteins <-
         all(groupFactors %in% unique(df$group))) {
       df <- df[df$group %in% groupFactors,]
       df$group <- factor(df$group, levels = groupFactors)
+      # fix sample ordering
+      sampleLevels <- c()
+      for (group in groupFactors) {
+        sampleLevels <- c(sampleLevels, 
+                          expDesign$samples[expDesign$groups==group])
+      }
+      df$Sample <- factor(df$Sample, levels = sampleLevels)
     }
     
     p <- ggplot(df, aes(x = Sample, y = Number, fill = group)) +
@@ -474,8 +481,15 @@ plotMissingValues <-
         all(groupFactors %in% unique(df$group))) {
       df <- df[df$group %in% groupFactors, ]
       df$group <- factor(df$group, levels = groupFactors)
+      
+      # fix sample ordering
+      sampleLevels <- c()
+      for (group in groupFactors) {
+        sampleLevels <- c(sampleLevels, 
+                          expDesign$samples[expDesign$groups==group])
+      }
+      df$Sample <- factor(df$Sample, levels = sampleLevels)
     }
-    
     p <- ggplot(df, aes(x = Sample, y = Number, fill = group)) +
       geom_bar(stat = "identity") +
       scale_fill_manual(values = myGroupColors) +
@@ -537,6 +551,13 @@ plotContaminants <-
         contsInts[contsInts$group %in% groupFactors, ]
       contsInts$group <-
         factor(contsInts$group, levels = groupFactors)
+      # fix sample ordering
+      sampleLevels <- c()
+      for (group in groupFactors) {
+        sampleLevels <- c(sampleLevels, 
+                          expDesign$samples[expDesign$groups==group])
+      }
+      contsInts$Sample <- factor(contsInts$Sample, levels = sampleLevels)
     }
     
     p <-

--- a/amica/server.R
+++ b/amica/server.R
@@ -278,8 +278,14 @@ server <- function(input, output, session) {
       object <- object[object$group %in% reacValues$groupFactors,]
       object$group <-
         factor(object$group, levels = reacValues$groupFactors)
+      # fix sample ordering
+      sampleLevels <- c()
+      for (group in reacValues$groupFactors) {
+        sampleLevels <- c(sampleLevels, 
+                          reacValues$expDesign$samples[reacValues$expDesign$groups==group])
+      }
+      object$colname <- factor(object$colname, levels = sampleLevels)
     }
-    
     object
   })
   


### PR DESCRIPTION
Fix works for following QC plots: 
- Boxplot
- Relative Contaminant Plot
- Number of id. proteins plot
- Missing values plot